### PR TITLE
Added removable-media to available plugs

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,6 +38,7 @@ apps:
           - desktop
           - wayland
           - desktop-legacy
+          - removable-media
 
 parts:
     musescore:


### PR DESCRIPTION
My media/files reside in a mounted directory of /media. The snap does not by default allow connecting to this directory without the removable-media plug.