### PR TITLE
Fix build of 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,4 @@ Some snap interfaces need to be connected manually:
     sudo snap connect musescore:network-manager
     sudo snap connect musescore:cups-control
 
-But the application can work wihout them.
+But the application can work without them.

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -96,6 +96,7 @@ parts:
             - libegl1-mesa-dev
             # QT
             - qtbase5-dev
+            - qt5-default
             - qttools5-dev
             - qttools5-dev-tools
             - qtwebengine5-dev


### PR DESCRIPTION
In my tests it seems only the lack of qt5 default detection was broken. The proposed change gets my build to complete again.

```
Building qt5-gtk-platform 
Skipping stage desktop-qt5 (already ran)
Skipping stage selective-checkout (already ran)
Staging musescore 
Staging qt5-gtk-platform 
Priming desktop-qt5 
This part is missing libraries that cannot be satisfied with any available stage-packages known to snapcraft:
- libgdk-x11-2.0.so.0
- libgtk-x11-2.0.so.0
These dependencies can be satisfied via additional parts or content sharing. Consider validating configured filesets if this dependency was built.
Priming selective-checkout 
Priming musescore 
Priming qt5-gtk-platform 
Snapping |                                                                                                                                                                          
Snapped musescore_3.6_amd64.snap
```

Please let me know if that x11 lib warning has existed before or if that is a new thing to look into.