### PR TITLE
Fix stable builds

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,7 +71,7 @@ parts:
             snapcraftctl pull
             "$SNAPCRAFT_STAGE"/scriptlets/selective-checkout \
                         --release-tag-prefix='v' \
-                        --stable-tag-pattern="^([[:digit:]]\.){1,2}[[:digit:]]$" \
+                        --stable-tag-pattern="^([[:digit:]]\.){1,2}[[:digit:]](\.[[:digit:]])+$" \
                         --force-stable
         build-packages:
             #- extra-cmake-modules

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -127,6 +127,7 @@ parts:
             - libqt5help5
             - libqt5network5
             - libqt5printsupport5
+            - libqt5quickwidgets5
             - libqt5sql5
             - libqt5svg5
             - libqt5webkit5


### PR DESCRIPTION
A small fix for a missing lib and a change to make it able to pick up the recent [v3.6.1](https://github.com/musescore/MuseScore/releases/tag/v3.6.1)